### PR TITLE
Un-blacklisted Mules

### DIFF
--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -6,7 +6,6 @@
 		/datum/species/nabber = list(/datum/job/ai, /datum/job/cyborg, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/chemist,
 									 /datum/job/roboticist, /datum/job/cargo_tech, /datum/job/chef, /datum/job/engineer, /datum/job/doctor, /datum/job/bartender),
 		/datum/species/vox = list(/datum/job/ai, /datum/job/cyborg),
-		/datum/species/human/mule = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant)
 	)
 
 #define HUMAN_ONLY_JOBS /datum/job/captain, /datum/job/hop, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/representative, /datum/job/sea, /datum/job/pathfinder, /datum/job/rd


### PR DESCRIPTION
### About

Mules can now play any job a normal human can.

### Why Tho?

Adds more option for user experience

### Documented Testing?

Setting Species to Mule
![Mule unblacklist 1](https://user-images.githubusercontent.com/68963748/119880696-80fb8200-befa-11eb-9a91-12457cd5f18c.png)

Jobs
![Mule unblacklist 2](https://user-images.githubusercontent.com/68963748/119880746-8d7fda80-befa-11eb-9c31-1985022efc29.png)
(previously they would list species restricted or the like.)

Changelog:
🆑 DatBoiTim
add: Mules are on the same White/Blacklist as other Humans.
🆑 