### PR TITLE
Allows hoodies in all civilian loadouts

### DIFF
--- a/maps/torch/loadout/loadout_suit.dm
+++ b/maps/torch/loadout/loadout_suit.dm
@@ -48,11 +48,9 @@
 	allowed_branches = CIVILIAN_BRANCHES
 
 /datum/gear/suit/hoodie
-	allowed_roles = CASUAL_ROLES
 	allowed_branches = CIVILIAN_BRANCHES
 
 /datum/gear/suit/hoodie_sel
-	allowed_roles = CASUAL_ROLES
 	allowed_branches = CIVILIAN_BRANCHES
 
 /datum/gear/suit/labcoat


### PR DESCRIPTION
I absolutely REFUSE to believe that a poncho can somehow be formal work gear and a hoodie cannot. This only takes off the "casual uniform" limit on it, it's still only available to civilians.

:cl: Spyroshark
tweak: All civilian jobs can now equip hoodies in their loadout.
/:cl: