### PR TITLE
fixes large boxes not being wrappable

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -29,6 +29,11 @@
 	var/foldable = /obj/item/stack/material/cardboard	// BubbleWrap - if set, can be folded (when empty) into a sheet of cardboard
 	allow_slow_dump = TRUE
 
+/obj/item/storage/box/attackby(obj/item/W, mob/user)
+	if(istype(W, /obj/item/stack/package_wrap))
+		return
+	. = ..()
+
 /obj/item/storage/box/large
 	name = "large box"
 	icon_state = "largebox"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Adds a return to box attackby() that makes you wrap large boxes instead of putting the package wrap in them

🆑
bugfix: Fixes large boxes being unwrappable
/🆑