### PR TITLE
Chorus Womb Fix+Improvements

### DIFF
--- a/code/modules/mob/living/carbon/alien/chorus/buildings/generic.dm
+++ b/code/modules/mob/living/carbon/alien/chorus/buildings/generic.dm
@@ -109,9 +109,13 @@
 	to_chat(C, SPAN_WARNING("You extend \the [src] [extend_text]."))
 	a.visible_message(SPAN_DANGER("\The [a] [growth_verb] [through_text]!"))
 
-
-/obj/structure/chorus/spawner/can_activate()
-	return TRUE
+//Checks for base activation conditions before spawner specifics. Why? Because there's a massive global list of various mobs being iterated.
+//This proc used to just outright return TRUE for whatever reason.
+/obj/structure/chorus/spawner/can_activate(var/mob/living/carbon/alien/chorus/C, var/warning = TRUE)
+	if(..())
+		for(var/mob/observer/ghost/ghost in GLOB.player_list) //No player ghost GLOB :(
+			if(MODE_DEITY in ghost.client.prefs.be_special_role)
+				return TRUE
 
 /obj/structure/chorus/spawner/activate()
 	for(var/mob/observer/ghost/ghost in GLOB.player_list)

--- a/code/modules/mob/living/carbon/alien/chorus/buildings/generic.dm
+++ b/code/modules/mob/living/carbon/alien/chorus/buildings/generic.dm
@@ -120,13 +120,19 @@
 /obj/structure/chorus/spawner/activate()
 	for(var/mob/observer/ghost/ghost in GLOB.player_list)
 		if(MODE_DEITY in ghost.client.prefs.be_special_role)
-			to_chat(ghost, SPAN_NOTICE("A chorus spawn is available! <a href='?src=\ref[src];jump=1'>(Jump)</a>"))
+			to_chat(ghost, SPAN_NOTICE("A chorus spawn is available! (<a href='?src=\ref[src]'>(Join)</a>)"))
 
-/obj/structure/chorus/spawner/OnTopic(user, href_list)
-	if(href_list["jump"] && istype(user,/mob/observer/ghost))
-		var/mob/M = user
-		M.forceMove(get_turf(src))
-		return TOPIC_HANDLED
+/obj/structure/chorus/spawner/OnTopic(var/mob/user, href_list)
+	if(href_list["src"] && istype(user,/mob/observer/ghost))
+		if(GLOB.chorus.can_become_antag(user.mind))
+			if(!owner.use_resource(activation_cost_resource, activation_cost_amount))
+				var/datum/chorus_resource/resource = owner.get_resource(activation_cost_resource)
+				to_chat(user, SPAN_WARNING("\The [src] needs [activation_cost_amount - resource.amount] more [resource.name] in order to spawn."))
+				return
+			announce_ghost_joinleave(user, 0, "They have joined a chorus")
+			var/mob/living/carbon/alien/chorus/sac = new(get_turf(src), owner)
+			sac.ckey = user.ckey
+			return TOPIC_HANDLED
 	. = ..()
 
 /obj/structure/chorus/spawner/attack_ghost(var/mob/observer/ghost/user)

--- a/code/modules/mob/living/carbon/alien/chorus/buildings/generic.dm
+++ b/code/modules/mob/living/carbon/alien/chorus/buildings/generic.dm
@@ -109,7 +109,7 @@
 	to_chat(C, SPAN_WARNING("You extend \the [src] [extend_text]."))
 	a.visible_message(SPAN_DANGER("\The [a] [growth_verb] [through_text]!"))
 
-//Checks for base activation conditions before spawner specifics. Why? Because there's a massive global list of various mobs being iterated.
+//Checks for base activation conditions before spawner specifics. Why? Because there's a massive global list of various mobs being iterated through, to check that there's even eligible ghosts.
 //This proc used to just outright return TRUE for whatever reason.
 /obj/structure/chorus/spawner/can_activate(var/mob/living/carbon/alien/chorus/C, var/warning = TRUE)
 	if(..())
@@ -134,13 +134,3 @@
 			sac.ckey = user.ckey
 			return TOPIC_HANDLED
 	. = ..()
-
-/obj/structure/chorus/spawner/attack_ghost(var/mob/observer/ghost/user)
-	if(GLOB.chorus.can_become_antag(user.mind))
-		if(!owner.use_resource(activation_cost_resource, activation_cost_amount))
-			var/datum/chorus_resource/resource = owner.get_resource(activation_cost_resource)
-			to_chat(user, SPAN_WARNING("\The [src] needs [activation_cost_amount - resource.amount] more [resource.name] in order to spawn."))
-			return
-		announce_ghost_joinleave(user, 0, "They have joined a chorus")
-		var/mob/living/carbon/alien/chorus/sac = new(get_turf(src), owner)
-		sac.ckey = user.ckey


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

## About
There was an issue with Chorus Wombs spawning the chorus. I have made the code now functional, and streamlined.

How?
Originally, it would activate, send a message to ghosts with a link, jump them to the womb, then requiring them to click on the womb to spawn, checking and draining resources as appropriate.

With this PR, clicking the on the womb is no longer needed. Click on the link in the chat and it spawns you on the womb.

I have also added some activation checks to ensure chorus don't activate the womb if there's no ghosts available for it. Decreases potential chat spam.

## The Long and Short of It
Activation Checks for the Womb are properly configured.
Use of the womb from the POV of ghosts is now much simpler(and functional)

## Testing Images and Procedure
![Chorus Womb Fixed](https://user-images.githubusercontent.com/68963748/132146151-4ec089b6-d168-4969-80cb-577f9c2b7128.png)
Successful test(Granted I commented out the resource checks for speed's sake)

Procedure:
Spawn Growth Womb
Aghost
Advanced proc call activate()
Finished
Click on chat message

Done

## Changelog
:cl: DatBoiTim
code: Chorus Womb has activation checks to decrease chat spam. Based on presence of valid ghosts to summon.
tweak: Streamlined ghost usage of Chorus wombs